### PR TITLE
Add space after rst syntax to fix rendering

### DIFF
--- a/locales/ja/LC_MESSAGES/contributing.po
+++ b/locales/ja/LC_MESSAGES/contributing.po
@@ -117,7 +117,7 @@ msgid ""
 "<https://github.com/orgs/atsphinx/discussions>`_."
 msgstr ""
 "もし「Sphinx拡張のアイデアはある」「でも自分で実装するのはちょっと難しい」"
-"といった場合は、アイデアだけを `OrganizationのDiscussion <https://github.com/orgs/atsphinx/discussions>`_"
+"といった場合は、アイデアだけを `OrganizationのDiscussion <https://github.com/orgs/atsphinx/discussions>`_ "
 "内に登録してみてください。"
 
 #: ../../contents/contributing.rst:54


### PR DESCRIPTION
Fix rendering
<img width="1134" alt="スクリーンショット 2025-05-10 15 44 20" src="https://github.com/user-attachments/assets/e9a09a8a-fbbb-48e6-b9aa-a82cf301dfe0" />
